### PR TITLE
chore: move alert on top of page

### DIFF
--- a/templates/uadmin/default/profile.html
+++ b/templates/uadmin/default/profile.html
@@ -87,6 +87,17 @@
               {{end}}
             </div>
           </div>
+          {{if .IsUpdated}}
+          {{if .Status}}
+          <div class="alert alert-warning">
+            <strong><i class="fa fa-exclamation"></i></strong>&nbsp;{{.Notif}}
+          </div>
+          {{else}}
+          <div class="alert alert-info">
+            <strong>{{Tf "uadmin/system" .Language.Code "Info:"}}</strong>&nbsp;&nbsp;{{Tf "uadmin/system" .Language.Code "Changes Successfully Applied!"}}
+          </div>
+          {{end}} {{/* if .Status */}}
+        {{end}} {{/* if .IsUpdated */}}
           <div class="col-sm-9">
             <div class="form-horizontal form-signin">
             {{range $fIndex, $value := .Schema.Fields}}
@@ -159,17 +170,6 @@
                 </div>
               </div>
             </div>
-            {{if .IsUpdated}}
-              {{if .Status}}
-              <div class="alert alert-warning">
-                <strong><i class="fa fa-exclamation"></i></strong>&nbsp;{{.Notif}}
-              </div>
-              {{else}}
-              <div class="alert alert-info">
-                <strong>{{Tf "uadmin/system" .Language.Code "Info:"}}</strong>&nbsp;&nbsp;{{Tf "uadmin/system" .Language.Code "Changes Successfully Applied!"}}
-              </div>
-              {{end}} {{/* if .Status */}}
-            {{end}} {{/* if .IsUpdated */}}
           </div>
         </form>
       </div>

--- a/templates/uadmin/vilna/profile.html
+++ b/templates/uadmin/vilna/profile.html
@@ -87,6 +87,17 @@
               {{end}}
             </div>
           </div>
+          {{if .IsUpdated}}
+          {{if .Status}}
+          <div class="alert alert-warning">
+            <strong><i class="fa fa-exclamation"></i></strong>&nbsp;{{.Notif}}
+          </div>
+          {{else}}
+          <div class="alert alert-info">
+            <strong>{{Tf "uadmin/system" .Language.Code "Info:"}}</strong>&nbsp;&nbsp;{{Tf "uadmin/system" .Language.Code "Changes Successfully Applied!"}}
+          </div>
+          {{end}} {{/* if .Status */}}
+        {{end}} {{/* if .IsUpdated */}}
           <div class="col-sm-9">
             <div class="form-horizontal form-signin">
             {{range $fIndex, $value := .Schema.Fields}}
@@ -159,17 +170,6 @@
                 </div>
               </div>
             </div>
-            {{if .IsUpdated}}
-              {{if .Status}}
-              <div class="alert alert-warning">
-                <strong><i class="fa fa-exclamation"></i></strong>&nbsp;{{.Notif}}
-              </div>
-              {{else}}
-              <div class="alert alert-info">
-                <strong>{{Tf "uadmin/system" .Language.Code "Info:"}}</strong>&nbsp;&nbsp;{{Tf "uadmin/system" .Language.Code "Changes Successfully Applied!"}}
-              </div>
-              {{end}} {{/* if .Status */}}
-            {{end}} {{/* if .IsUpdated */}}
           </div>
         </form>
       </div>


### PR DESCRIPTION
In this PR:
move the profile page alert to the top of the page.
the previous alert was at the bottom of the page, it's not user-friendly
<img width="600" alt="SCR-20240907-mhd" src="https://github.com/user-attachments/assets/49e27743-5dc4-45e9-92b8-7ff208eb62d8">

relate to the [PR](https://github.com/arbrix/uadmin/pull/17)

